### PR TITLE
Exceptions should favor `raise` over `fail`

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2674,45 +2674,43 @@ Rubyコミュニティ内でもスタイルについての統一見解が存在�
 
 ## 例外
 
-* <a name="fail-method"></a>
-  例外は`fail`を使って発生させましょう。
-  `raise`は例外をキャッチして、再度発生させるときにのみ使いましょう
-  (何故なら、ここでは失敗(fail)ではなく、明示的に意図的に例外を上げ(raise)ているからです)。
-<sup>[[link](#fail-method)]</sup>
+* <a name="prefer-raise-over-fail"></a>
+  例外は`fail`より`raise`を使いましょう。
+<sup>[[link](#prefer-raise-over-fail)]</sup>
 
   ```Ruby
-  begin
-    fail 'Oops'
-  rescue => error
-    raise if error.message != 'Oops'
-  end
+  # 悪い例
+  fail SomeException, 'message'
+
+  # 良い例
+  raise SomeException, 'message'
   ```
 
 * <a name="no-explicit-runtimeerror"></a>
-  ２引数の`fail/raise`では、`RuntimeError`を明示しないようにしましょう。
+  ２引数の`raise`では、`RuntimeError`を明示しないようにしましょう。
 <sup>[[link](#no-explicit-runtimeerror)]</sup>
 
   ```Ruby
   # 悪い例
-  fail RuntimeError, 'message'
+  raise RuntimeError, 'message'
 
   # 良い例 - デフォルトでRuntimeErrorが発生します
-  fail 'message'
+  raise 'message'
   ```
 
 * <a name="exception-class-messages"></a>
-  `fail/raise`の引数としては例外クラスのインスタンスよりも、
+  `raise`の引数としては例外クラスのインスタンスよりも、
   例外クラスとメッセージをそれぞれの引数で渡す方を使いましょう。
 <sup>[[link](#exception-class-messages)]</sup>
 
   ```Ruby
   # 悪い例
-  fail SomeException.new('message')
-  # `fail SomeException.new('message'), backtrace`とする書き方が存在しないことに注意しましょう。
+  raise SomeException.new('message')
+  # `raise SomeException.new('message'), backtrace`とする書き方が存在しないことに注意しましょう。
 
   # 良い例
-  fail SomeException, 'message'
-  # `fail SomeException, 'message', backtrace`の用法と一貫性があります
+  raise SomeException, 'message'
+  # `raise SomeException, 'message', backtrace`の用法と一貫性があります
   ```
 
 * <a name="no-return-ensure"></a>
@@ -2725,7 +2723,7 @@ Rubyコミュニティ内でもスタイルについての統一見解が存在�
 
   ```Ruby
   def foo
-    fail
+    raise
   ensure
     return 'very bad idea'
   end

--- a/README.md
+++ b/README.md
@@ -2702,7 +2702,7 @@ no parameters.
 
 ## Exceptions
 
-* <a name="prefer-raise"></a>
+* <a name="prefer-raise-over-fail"></a>
   Prefer `raise` over `fail` for exceptions.
   <sup>[[link](#prefer-raise-over-fail)]</sup>
 

--- a/README.md
+++ b/README.md
@@ -2702,46 +2702,44 @@ no parameters.
 
 ## Exceptions
 
-* <a name="fail-method"></a>
-  Signal exceptions using the `fail` method. Use `raise` only when catching an
-  exception and re-raising it (because here you're not failing, but explicitly
-  and purposefully raising an exception).
-<sup>[[link](#fail-method)]</sup>
+* <a name="prefer-raise"></a>
+  Prefer `raise` over `fail` for exceptions.
+  <sup>[[link](#prefer-raise-over-fail)]</sup>
 
   ```Ruby
-  begin
-    fail 'Oops'
-  rescue => error
-    raise if error.message != 'Oops'
-  end
+  # bad
+  fail SomeException, 'message'
+
+  # good
+  raise SomeException, 'message'
   ```
 
 * <a name="no-explicit-runtimeerror"></a>
   Don't specify `RuntimeError` explicitly in the two argument version of
-  `fail/raise`.
+  `raise`.
 <sup>[[link](#no-explicit-runtimeerror)]</sup>
 
   ```Ruby
   # bad
-  fail RuntimeError, 'message'
+  raise RuntimeError, 'message'
 
   # good - signals a RuntimeError by default
-  fail 'message'
+  raise 'message'
   ```
 
 * <a name="exception-class-messages"></a>
   Prefer supplying an exception class and a message as two separate arguments
-  to `fail/raise`, instead of an exception instance.
+  to `raise`, instead of an exception instance.
 <sup>[[link](#exception-class-messages)]</sup>
 
   ```Ruby
   # bad
-  fail SomeException.new('message')
-  # Note that there is no way to do `fail SomeException.new('message'), backtrace`.
+  raise SomeException.new('message')
+  # Note that there is no way to do `raise SomeException.new('message'), backtrace`.
 
   # good
-  fail SomeException, 'message'
-  # Consistent with `fail SomeException, 'message', backtrace`.
+  raise SomeException, 'message'
+  # Consistent with `raise SomeException, 'message', backtrace`.
   ```
 
 * <a name="no-return-ensure"></a>
@@ -2753,7 +2751,7 @@ no parameters.
 
   ```Ruby
   def foo
-    fail
+    raise
   ensure
     return 'very bad idea'
   end


### PR DESCRIPTION
https://github.com/bbatsov/ruby-style-guide/issues/512

での変更の追従で、failではなくraiseを使うように変更しました。
